### PR TITLE
fix: Prevent app getting stuck on loading spinner after login

### DIFF
--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -188,26 +188,18 @@ export const UserPreferencesProvider = ({ children, currentUser }: UserPreferenc
     if (mongoDbUserId) {
       fetchAndSetUserPreferences(mongoDbUserId);
     } else {
-      // mongoDbUserId is null
-      let newIsLoadingState;
-      if (currentUser?.uid) {
-        // Firebase user is present, but mongoDbUserId is not (yet).
-        // This means AppContent's onAuthStateChanged might be in the process of setting it.
-        // Keep isLoading true.
-        newIsLoadingState = true;
-        console.log("[UserPreferencesContext] Main Auth/MongoID Effect: Firebase user exists, mongoDbUserId is null. Maintaining isLoading: true (waiting for mongoDbUserId).");
-      } else {
-        // No mongoDbUserId AND no Firebase currentUser. User is definitively logged out or app is in initial state.
-        newIsLoadingState = false;
-        console.log("[UserPreferencesContext] Main Auth/MongoID Effect: No mongoDbUserId and no currentUser. Setting isLoading: false.");
-      }
-
+      // mongoDbUserId is null.
+      // Regardless of whether currentUser (Firebase user) exists, if we don't have a mongoDbUserId,
+      // the process of loading/linking to a backend profile is not actively in progress *via this context's primary mechanism*.
+      // AppContent might be trying to get mongoDbUserId if currentUser exists (which would then trigger the `if (mongoDbUserId)` block above).
+      // But UserPreferencesContext itself should reflect isLoading:false if mongoDbUserId is definitively null at this point in its own effect.
+      console.log("[UserPreferencesContext] Main Auth/MongoID Effect: mongoDbUserId is null. Setting isLoading: false.");
       setPreferencesState(prev => ({
         ...initialDefaultPreferences,
         theme: prev.theme, // Preserve theme choice
-        isLoading: newIsLoadingState
+        isLoading: false // Key change: always false if mongoDbUserId is null here
       }));
-      applyTheme(initialDefaultPreferences.theme);
+      applyTheme(initialDefaultPreferences.theme); // Apply default theme or preserved theme
       setPassedCandidateIdsState(new Set());
       setPassedCompanyIdsState(new Set());
       setFullBackendUserState(null);


### PR DESCRIPTION
This commit resolves an issue where the application would remain on a full-page loading spinner indefinitely after you successfully authenticate with Firebase, if the subsequent process of linking to or fetching the backend user profile failed.

The root cause was in `UserPreferencesContext.tsx`. If a Firebase user (`currentUser`) was present but `mongoDbUserId` was (or became) `null` (e.g., due to a backend API error during profile fetch/creation), the context would keep `preferences.isLoading` as `true`. This, in turn, caused `AppContent` to continuously display its main loading spinner.

The fix involves modifying the `useEffect` hook in `UserPreferencesContext.tsx` that manages `preferences.isLoading` based on `mongoDbUserId` and `currentUser`. Now, if `mongoDbUserId` is `null`, `preferences.isLoading` is definitively set to `false`, regardless of whether a Firebase `currentUser` exists. This ensures that the loading phase for user-specific backend data is considered concluded, even if it concluded with an error (i.e., no `mongoDbUserId`).

The application should now always transition out of the initial loading state after a Firebase login. If backend data retrieval fails, it may present a degraded experience or an error specific to profile loading, but it will no longer hang on the generic loading spinner.